### PR TITLE
disableDayClick: hide text inputs and gray out days display

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "calendar",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Generic calendar component for Turn",
   "main": "dist/calendar.js",
   "authors": [

--- a/dist/turnCalendar.css
+++ b/dist/turnCalendar.css
@@ -208,3 +208,6 @@ p.clear {
 
 .clear {
   clear: both; }
+
+.no-left-margin {
+  margin-left: 0 !important; }

--- a/dist/turnCalendar.js
+++ b/dist/turnCalendar.js
@@ -1371,11 +1371,14 @@ angular.module("turnCalendar.html", []).run(["$templateCache", function($templat
     "    <div class=\"turn-calendar-div\" ng-show=\"calendarEnabled\">\n" +
     "        <div class=\"turn-calendar-input-container\">            \n" +
     "            <div class=\"turn-calendar-input\">\n" +
-    "                <span ng-show=\"isNotSingleDateMode\" class=\"turn-calendar-from\">From</span>\n" +
-    "                <input class=\"turn-calendar-input-box\" type=\"text\" ng-model=\"startDateString\" ng-change=\"changeStartDate()\" ng-disabled=\"isDayClickDisabledMode\" />\n" +
-    "                <span ng-show=\"isNotSingleDateMode\" class=\"turn-calendar-to\">To</span>\n" +
-    "                <input ng-show=\"isNotSingleDateMode\" class=\"turn-calendar-input-box\" type=\"text\" ng-model=\"endDateString\" ng-change=\"changeEndDate()\" ng-disabled=\"isDayClickDisabledMode\" />\n" +
-    "                <span ng-show=\"priorButtons.length && isNotSingleDateMode\" class=\"turn-calendar-prior-label\">Prior</span>\n" +
+    "                <span ng-show=\"isNotSingleDateMode && !isDayClickDisabledMode\" class=\"turn-calendar-from\">From</span>\n" +
+    "                <input ng-show=\"!isDayClickDisabledMode\" class=\"turn-calendar-input-box\" type=\"text\" ng-model=\"startDateString\" ng-change=\"changeStartDate()\" />\n" +
+    "                <span ng-show=\"isNotSingleDateMode && !isDayClickDisabledMode\" class=\"turn-calendar-to\">To</span>\n" +
+    "                <input ng-show=\"isNotSingleDateMode && !isDayClickDisabledMode\" class=\"turn-calendar-input-box\" type=\"text\" ng-model=\"endDateString\" ng-change=\"changeEndDate()\" />\n" +
+    "                <span ng-show=\"priorButtons.length && isNotSingleDateMode\" \n" +
+    "                        class=\"turn-calendar-prior-label\"\n" +
+    "                        ng-class=\"{'no-left-margin': isDayClickDisabledMode}\">\n" +
+    "                        Prior</span>\n" +
     "                <button ng-show=\"isNotSingleDateMode\" class=\"turn-calendar-prior\" ng-repeat=\"range in priorButtons\" \n" +
     "                        ng-click=\"selectRange(range, $index)\"\n" +
     "                        ng-class=\"{'turn-calendar-prior-left': $index == 0, \n" +
@@ -1410,7 +1413,7 @@ angular.module("turnCalendar.html", []).run(["$templateCache", function($templat
     "                                           'turn-calendar-selected-daily': day.selectMode == 'daily',\n" +
     "                                           'turn-calendar-selected-weekly': day.selectMode == 'weekly',\n" +
     "                                           'turn-calendar-selected-monthly': day.selectMode == 'monthly',\n" +
-    "                                           'turn-calendar-unavailable': day.isUnavailable,\n" +
+    "                                           'turn-calendar-unavailable': day.isUnavailable || isDayClickDisabledMode,\n" +
     "                                           'turn-calendar-unclickable': isDayClickDisabledMode,\n" +
     "                                           'turn-calendar-date': day.date.getDate()}\"\n" +
     "                                ng-mouseenter=\"mouseEnter(day)\"\n" +

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calendar",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Generic calendar component for Turn",
   "main": "dist/calendar.js",
   "scripts": {

--- a/src/turnCalendar.html
+++ b/src/turnCalendar.html
@@ -5,11 +5,14 @@
     <div class="turn-calendar-div" ng-show="calendarEnabled">
         <div class="turn-calendar-input-container">            
             <div class="turn-calendar-input">
-                <span ng-show="isNotSingleDateMode" class="turn-calendar-from">From</span>
-                <input class="turn-calendar-input-box" type="text" ng-model="startDateString" ng-change="changeStartDate()" ng-disabled="isDayClickDisabledMode" />
-                <span ng-show="isNotSingleDateMode" class="turn-calendar-to">To</span>
-                <input ng-show="isNotSingleDateMode" class="turn-calendar-input-box" type="text" ng-model="endDateString" ng-change="changeEndDate()" ng-disabled="isDayClickDisabledMode" />
-                <span ng-show="priorButtons.length && isNotSingleDateMode" class="turn-calendar-prior-label">Prior</span>
+                <span ng-show="isNotSingleDateMode && !isDayClickDisabledMode" class="turn-calendar-from">From</span>
+                <input ng-show="!isDayClickDisabledMode" class="turn-calendar-input-box" type="text" ng-model="startDateString" ng-change="changeStartDate()" />
+                <span ng-show="isNotSingleDateMode && !isDayClickDisabledMode" class="turn-calendar-to">To</span>
+                <input ng-show="isNotSingleDateMode && !isDayClickDisabledMode" class="turn-calendar-input-box" type="text" ng-model="endDateString" ng-change="changeEndDate()" />
+                <span ng-show="priorButtons.length && isNotSingleDateMode" 
+                        class="turn-calendar-prior-label"
+                        ng-class="{'no-left-margin': isDayClickDisabledMode}">
+                        Prior</span>
                 <button ng-show="isNotSingleDateMode" class="turn-calendar-prior" ng-repeat="range in priorButtons" 
                         ng-click="selectRange(range, $index)"
                         ng-class="{'turn-calendar-prior-left': $index == 0, 
@@ -44,7 +47,7 @@
                                            'turn-calendar-selected-daily': day.selectMode == 'daily',
                                            'turn-calendar-selected-weekly': day.selectMode == 'weekly',
                                            'turn-calendar-selected-monthly': day.selectMode == 'monthly',
-                                           'turn-calendar-unavailable': day.isUnavailable,
+                                           'turn-calendar-unavailable': day.isUnavailable || isDayClickDisabledMode,
                                            'turn-calendar-unclickable': isDayClickDisabledMode,
                                            'turn-calendar-date': day.date.getDate()}"
                                 ng-mouseenter="mouseEnter(day)"

--- a/src/turnCalendar.scss
+++ b/src/turnCalendar.scss
@@ -283,3 +283,7 @@ p.clear {
 .clear {
   clear: both;  
 }
+
+.no-left-margin {
+  margin-left: 0 !important;
+}

--- a/test/turnCalendarDirective.js
+++ b/test/turnCalendarDirective.js
@@ -186,17 +186,28 @@ describe('turnCalendar directive', function() {
             $rootScope.$digest();
         });
 
-        it('should have disabled text input for dates ', function () {
-            expect(element.find('input').attr('disabled')).toBe('disabled');
+        it('should not show text input for dates ', function () {
+            expect(element.find('span').eq(1).css('display')).toBe('none'); // 'From'
+            expect(element.find('input').eq(0).css('display')).toBe('none'); // Date
+            expect(element.find('span').eq(2).css('display')).toBe('none'); // 'To'
+            expect(element.find('input').eq(1).css('display')).toBe('none'); // Date
+        });
+
+        it('should set left margin of prior days selection to zero ', function () {
+            expect(element.find('span').eq(3).hasClass('no-left-margin')).toBe(true); // 'Prior'
         });
 
         it('should not show month navigation buttons ', function () {
-            expect(element.find('div').eq(7).css('display')).toBe('none');
-            expect(element.find('div').eq(9).css('display')).toBe('none');
+            expect(element.find('div').eq(7).css('display')).toBe('none'); // Left arrow
+            expect(element.find('div').eq(9).css('display')).toBe('none'); // Right arrow
         });
 
         it('has turn-calendar-unclickable class applied to every day in turn-calendar-table ', function () {
             expect(element.find('table').eq(0).find('td').hasClass('turn-calendar-unclickable')).toBe(true);
+        });
+
+        it('has turn-calendar-unavailable class applied to every day in turn-calendar-table ', function () {
+            expect(element.find('table').eq(0).find('td').hasClass('turn-calendar-unavailable')).toBe(true);
         });
     });
 


### PR DESCRIPTION
For `disableDayClick` mode, also hide text inputs for date, and gray out every day in the calendar.

This is a UX requirement.
