### PR TITLE
Fix typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "calendar",
   "version": "0.0.4",
   "description": "Generic calendar component for Turn",
-  "main": "dist/calendar.js",
+  "main": "dist/turnCalendar.js",
   "scripts": {
     "test": "grunt test --verbose"
   },


### PR DESCRIPTION
Project main property refers directly to the turnCalendar distribution file.

When importing turn-calendar as a node module, the package's main property is consulted to determine which filesystem assets should be made available to a consumer.

The main property had designated a non-existent file as the importable asset.
